### PR TITLE
Remove unused include

### DIFF
--- a/OpteeCalls/OpteeCalls.c
+++ b/OpteeCalls/OpteeCalls.c
@@ -5,7 +5,6 @@
 #include <windows.h>
 
 #include <winioctl.h>
-#include <ntddksec.h>
 #include <trustedrt.h>
 
 #include <stdio.h>


### PR DESCRIPTION
`ntddksec.h` is not present in current versions of the WDK.

This change is required for [this PR](https://github.com/Microsoft/openenclave/pull/1299) over in Open Enclave.